### PR TITLE
Add unit tests with mocked AI

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your-openai-api-key
+GOOGLE_API_KEY=your-google-api-key

--- a/json/translateJSON_test.ts
+++ b/json/translateJSON_test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import translateJson, { type JSONObject } from "./translateJSON.ts";
+
+const stubTranslate = (text: string, lang: string) =>
+  Promise.resolve(`${text}-${lang}`);
+
+Deno.test("translates simple fields", async () => {
+  const input: JSONObject = { greeting: "Hello" };
+  const result = await translateJson(input, "fr", stubTranslate);
+  assert.deepEqual(result, { greeting: "Hello-fr" });
+});
+
+Deno.test("handles nested structures", async () => {
+  const input: JSONObject = {
+    a: "Hi",
+    nested: { b: ["World", 5, true] },
+  };
+  const result = await translateJson(input, "fr", stubTranslate);
+  assert.deepEqual(result, {
+    a: "Hi-fr",
+    nested: { b: ["World-fr", 5, true] },
+  });
+});

--- a/text/translateText.ts
+++ b/text/translateText.ts
@@ -5,12 +5,13 @@ import { HumanMessage } from "@langchain/core/messages";
 const translateText = async (
   text: string,
   targetLang: string,
-  chat: ChatOpenAI | ChatGoogleGenerativeAI
+  chat: ChatOpenAI | ChatGoogleGenerativeAI,
 ): Promise<string> => {
+  const prompt = `Translate the following text to ${targetLang}: ${text}. ` +
+    "Do not include any additional text or formatting. Just return the translated text. " +
+    "Text is aimed for a web application, so keep it concise and clear.";
   const response = await chat.invoke([
-    new HumanMessage(`Translate the following text to ${targetLang}: ${text}
-      Do not include any additional text or formatting. Just return the translated text.
-      Text is aimed for a web application, so keep it concise and clear.`),
+    new HumanMessage(prompt),
   ]);
   if (!response || !response.content) {
     throw new Error("Translation failed or returned empty content.");

--- a/text/translateText_test.ts
+++ b/text/translateText_test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import type { ChatOpenAI } from "@langchain/openai";
+import translateText from "./translateText.ts";
+
+class MockChat {
+  calls: unknown[][] = [];
+  constructor(private reply: unknown) {}
+  invoke(messages: unknown[]) {
+    this.calls.push(messages);
+    return Promise.resolve({ content: this.reply } as { content: unknown });
+  }
+}
+
+Deno.test("returns translated text", async () => {
+  const chat = new MockChat("Bonjour");
+  const result = await translateText(
+    "Hello",
+    "fr",
+    chat as unknown as ChatOpenAI,
+  );
+  assert.equal(result, "Bonjour");
+  assert.equal(chat.calls.length, 1);
+});
+
+Deno.test("throws if translation content missing", async () => {
+  const chat = new MockChat(undefined);
+  await assert.rejects(() =>
+    translateText("Hello", "fr", chat as unknown as ChatOpenAI)
+  );
+});
+
+Deno.test("throws if translation content is not string", async () => {
+  const chat = new MockChat(42 as unknown);
+  await assert.rejects(() =>
+    translateText("Hello", "fr", chat as unknown as ChatOpenAI)
+  );
+});


### PR DESCRIPTION
## Summary
- improve translateText prompt
- add example keys to `.env.sample`
- add unit tests for JSON and text translators

## Testing
- `deno fmt --check`
- `deno lint`
- `deno test`


------
https://chatgpt.com/codex/tasks/task_b_68511611bbec83308b84f581b4e96d87