### PR TITLE
Update API key handling

### DIFF
--- a/LangChainConfig.ts
+++ b/LangChainConfig.ts
@@ -1,37 +1,54 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
+/**
+ * Configuration options for creating a LangChain chat client.
+ *
+ * The API key must be provided explicitly instead of relying on
+ * environment variables. This allows consumers of the module to pass the
+ * credentials directly.
+ */
 export type LangChainConfig =
-  | { name: "openai"; model: "gpt-3.5-turbo" | "gpt-4" }
-  | { name: "google"; model: "gemini-1.5-pro" };
+  | { name: "openai"; model: "gpt-3.5-turbo" | "gpt-4"; apiKey: string }
+  | { name: "google"; model: "gemini-1.5-pro"; apiKey: string };
 
+/**
+ * Create a chat instance for the selected AI provider.
+ *
+ * @param aiEngine Configuration describing the provider, model and API key.
+ * @returns An initialized chat client ready to be used with the translation
+ *   helpers.
+ *
+ * @example
+ * ```ts
+ * import { configureLangChain } from "@baiq/translator";
+ * const chat = configureLangChain({
+ *   name: "openai",
+ *   model: "gpt-3.5-turbo",
+ *   apiKey: "YOUR_API_KEY",
+ * });
+ * ```
+ */
 export const configureLangChain = (
-  aiEngine: LangChainConfig
+  aiEngine: LangChainConfig,
 ): ChatOpenAI | ChatGoogleGenerativeAI => {
   switch (aiEngine.name) {
     case "openai":
-      if (!Deno.env.get("OPENAI_API_KEY")) {
-        throw new Error("OPENAI_API_KEY environment variable is not set.");
-      }
-
       return new ChatOpenAI({
-        openAIApiKey: Deno.env.get("OPENAI_API_KEY")!,
+        openAIApiKey: aiEngine.apiKey,
         modelName: aiEngine.model,
       });
 
     case "google":
-      if (!Deno.env.get("GOOGLE_API_KEY")) {
-        throw new Error("GOOGLE_API_KEY environment variable is not set.");
-      }
       return new ChatGoogleGenerativeAI({
-        apiKey: Deno.env.get("GOOGLE_API_KEY")!,
+        apiKey: aiEngine.apiKey,
         model: aiEngine.model,
       });
 
     default: {
       const _exhaustiveCheck: never = aiEngine;
       throw new Error(
-        `Unsupported AI engine: ${JSON.stringify(_exhaustiveCheck)}`
+        `Unsupported AI engine: ${JSON.stringify(_exhaustiveCheck)}`,
       );
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # translator
+
+Utilities for translating text or JSON data using LangChain chat models.
+
+## Usage
+
+```ts
+import { configureLangChain, translateJson, translateText } from "./mod.ts";
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-3.5-turbo",
+  apiKey: "YOUR_OPENAI_KEY",
+});
+
+const result = await translateText("Hello", "fr", chat);
+console.log(result); // Bonjour
+```
+
+### JSON translation
+
+```ts
+const data = { greeting: "Hello", nested: { bye: "Good bye" } };
+const translated = await translateJson(
+  data,
+  "fr",
+  (text, lang) => translateText(text, lang, chat),
+);
+console.log(translated);
+// { greeting: "Bonjour", nested: { bye: "Au revoir" } }
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+These small scripts demonstrate how to use the library.
+
+Run them with Deno after setting the appropriate API key in your environment:
+
+```sh
+deno run -A examples/translate_text.ts
+```

--- a/examples/translate_json.ts
+++ b/examples/translate_json.ts
@@ -1,0 +1,15 @@
+import { configureLangChain, translateJson, translateText } from "../mod.ts";
+
+const chat = configureLangChain({
+  name: "google",
+  model: "gemini-1.5-pro",
+  apiKey: Deno.env.get("GOOGLE_API_KEY") ?? "", // replace with your key
+});
+
+const data = { welcome: "Hello", nested: { bye: "Good bye" } };
+const translated = await translateJson(
+  data,
+  "fr",
+  (text, lang) => translateText(text, lang, chat),
+);
+console.log(JSON.stringify(translated, null, 2));

--- a/examples/translate_text.ts
+++ b/examples/translate_text.ts
@@ -1,0 +1,10 @@
+import { configureLangChain, translateText } from "../mod.ts";
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-3.5-turbo",
+  apiKey: Deno.env.get("OPENAI_API_KEY") ?? "", // replace with your key
+});
+
+const text = await translateText("Good morning", "fr", chat);
+console.log(text);

--- a/json/README.md
+++ b/json/README.md
@@ -1,0 +1,23 @@
+# `json` module
+
+Helpers for translating values of JSON objects.
+
+## Example
+
+```ts
+import { configureLangChain, translateJson, translateText } from "../mod.ts";
+
+const chat = configureLangChain({
+  name: "google",
+  model: "gemini-1.5-pro",
+  apiKey: "YOUR_GOOGLE_KEY",
+});
+
+const data = { greeting: "Hello" };
+const translated = await translateJson(
+  data,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+);
+console.log(translated); // { greeting: "Hola" }
+```

--- a/json/translateJSON.ts
+++ b/json/translateJSON.ts
@@ -1,3 +1,6 @@
+/**
+ * Representation of any JSON-compatible object used for translation.
+ */
 export type JSONObject = {
   [key: string]:
     | string
@@ -7,10 +10,24 @@ export type JSONObject = {
     | JSONObject;
 };
 
+/**
+ * Recursively translate the values of a JSON object.
+ *
+ * @param json The JSON object whose string fields should be translated.
+ * @param targetLang ISO language code the values will be translated to.
+ * @param translateTextFn Function used to translate individual strings.
+ * @returns A new JSON object with all translatable fields translated.
+ *
+ * @example
+ * ```ts
+ * const translated = await translateJson({ greeting: "Hello" }, "fr", translateText);
+ * // => { greeting: "Bonjour" }
+ * ```
+ */
 const translateJson = async (
   json: JSONObject,
   targetLang: string,
-  translateTextFn: (text: string, targetLang: string) => Promise<string>
+  translateTextFn: (text: string, targetLang: string) => Promise<string>,
 ): Promise<JSONObject> => {
   const result: JSONObject = {};
 
@@ -19,7 +36,7 @@ const translateJson = async (
       result[key] = await translateJson(
         value as JSONObject,
         targetLang,
-        translateTextFn
+        translateTextFn,
       );
       continue;
     } else if (Array.isArray(value)) {
@@ -31,12 +48,12 @@ const translateJson = async (
             return await translateJson(
               item as JSONObject,
               targetLang,
-              translateTextFn
+              translateTextFn,
             );
           } else {
             return item;
           }
-        })
+        }),
       );
     } else if (typeof value === "string") {
       result[key] = await translateTextFn(value, targetLang);

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,13 @@
 import translateJson from "./json/mod.ts";
 import translateText from "./text/mod.ts";
 import { configureLangChain, type LangChainConfig } from "./LangChainConfig.ts";
-export { translateJson, translateText, configureLangChain };
+
+/**
+ * Entry point exporting all translation utilities.
+ *
+ * Use {@link configureLangChain} to create a chat client and then pass it to
+ * {@link translateText} or combine it with {@link translateJson} to translate
+ * JSON structures.
+ */
+export { configureLangChain, translateJson, translateText };
 export type { LangChainConfig };

--- a/text/README.md
+++ b/text/README.md
@@ -1,0 +1,18 @@
+# `text` module
+
+Single text translation helper.
+
+## Example
+
+```ts
+import { configureLangChain, translateText } from "../mod.ts";
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-3.5-turbo",
+  apiKey: "YOUR_OPENAI_KEY",
+});
+
+const greeting = await translateText("Hello", "de", chat);
+console.log(greeting); // Hallo
+```

--- a/text/translateText.ts
+++ b/text/translateText.ts
@@ -2,6 +2,26 @@ import type { ChatOpenAI } from "@langchain/openai";
 import type { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { HumanMessage } from "@langchain/core/messages";
 
+/**
+ * Translate a text string using a provided LangChain chat client.
+ *
+ * @param text The text to translate.
+ * @param targetLang ISO code of the language the text should be translated to.
+ * @param chat A configured chat client from {@link configureLangChain}.
+ * @returns The translated text.
+ *
+ * @example
+ * ```ts
+ * const chat = configureLangChain({
+ *   name: "openai",
+ *   model: "gpt-3.5-turbo",
+ *   apiKey: "YOUR_API_KEY",
+ * });
+ * const translated = await translateText("Hello", "fr", chat);
+ * console.log(translated); // Bonjour
+ * ```
+ */
+
 const translateText = async (
   text: string,
   targetLang: string,


### PR DESCRIPTION
## Summary
- configure API key via params instead of env vars
- document functions with Doxygen examples
- add module READMEs and usage samples
- include example scripts

## Testing
- `deno fmt`
- `deno lint` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_b_68511801e0788330898dd68f15bbaf97