### PR TITLE
Add more models and CLI

### DIFF
--- a/LangChainConfig.ts
+++ b/LangChainConfig.ts
@@ -2,6 +2,25 @@ import { ChatOpenAI } from "@langchain/openai";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
 /**
+ * All supported OpenAI chat models.
+ */
+export type OpenAIModel =
+  | "gpt-3.5-turbo"
+  | "gpt-3.5-turbo-0125"
+  | "gpt-4"
+  | "gpt-4-turbo"
+  | "gpt-4o";
+
+/**
+ * All supported Google Generative AI chat models.
+ */
+export type GoogleModel =
+  | "gemini-pro"
+  | "gemini-pro-vision"
+  | "gemini-1.5-pro"
+  | "gemini-1.5-flash";
+
+/**
  * Configuration options for creating a LangChain chat client.
  *
  * The API key must be provided explicitly instead of relying on
@@ -9,8 +28,8 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
  * credentials directly.
  */
 export type LangChainConfig =
-  | { name: "openai"; model: "gpt-3.5-turbo" | "gpt-4"; apiKey: string }
-  | { name: "google"; model: "gemini-1.5-pro"; apiKey: string };
+  | { name: "openai"; model: OpenAIModel; apiKey: string }
+  | { name: "google"; model: GoogleModel; apiKey: string };
 
 /**
  * Create a chat instance for the selected AI provider.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ import { configureLangChain, translateJson, translateText } from "./mod.ts";
 
 const chat = configureLangChain({
   name: "openai",
-  model: "gpt-3.5-turbo",
+  model: "gpt-4o",
   apiKey: "YOUR_OPENAI_KEY",
 });
 
@@ -28,4 +28,26 @@ const translated = await translateJson(
 );
 console.log(translated);
 // { greeting: "Bonjour", nested: { bye: "Au revoir" } }
+```
+
+### CLI usage
+
+Translate a short text directly from the command line:
+
+```sh
+deno run jsr:@baiq/translator/script/translateText \
+  --engine openai \
+  --model gpt-4o \
+  --lang fr \
+  --text "Hello"
+```
+
+You can also translate a JSON file:
+
+```sh
+deno run jsr:@baiq/translator/script/translateJSON \
+  --engine google \
+  --model gemini-1.5-flash \
+  --lang fr \
+  --file data.json
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,23 @@ Run them with Deno after setting the appropriate API key in your environment:
 ```sh
 deno run -A examples/translate_text.ts
 ```
+
+Alternatively use the bundled CLI to translate text:
+
+```sh
+deno run jsr:@baiq/translator/script/translateText \
+  --engine openai \
+  --model gpt-4o \
+  --lang fr \
+  --text "Hello"
+```
+
+You can also translate JSON files:
+
+```sh
+deno run jsr:@baiq/translator/script/translateJSON \
+  --engine google \
+  --model gemini-1.5-flash \
+  --lang fr \
+  --file data.json
+```

--- a/examples/translate_json.ts
+++ b/examples/translate_json.ts
@@ -2,7 +2,7 @@ import { configureLangChain, translateJson, translateText } from "../mod.ts";
 
 const chat = configureLangChain({
   name: "google",
-  model: "gemini-1.5-pro",
+  model: "gemini-1.5-flash",
   apiKey: Deno.env.get("GOOGLE_API_KEY") ?? "", // replace with your key
 });
 

--- a/examples/translate_text.ts
+++ b/examples/translate_text.ts
@@ -2,7 +2,7 @@ import { configureLangChain, translateText } from "../mod.ts";
 
 const chat = configureLangChain({
   name: "openai",
-  model: "gpt-3.5-turbo",
+  model: "gpt-4o",
   apiKey: Deno.env.get("OPENAI_API_KEY") ?? "", // replace with your key
 });
 

--- a/json/README.md
+++ b/json/README.md
@@ -9,7 +9,7 @@ import { configureLangChain, translateJson, translateText } from "../mod.ts";
 
 const chat = configureLangChain({
   name: "google",
-  model: "gemini-1.5-pro",
+  model: "gemini-1.5-flash",
   apiKey: "YOUR_GOOGLE_KEY",
 });
 
@@ -20,4 +20,14 @@ const translated = await translateJson(
   (text, lang) => translateText(text, lang, chat),
 );
 console.log(translated); // { greeting: "Hola" }
+```
+
+### CLI
+
+```sh
+deno run jsr:@baiq/translator/script/translateJSON \
+  --engine google \
+  --model gemini-1.5-flash \
+  --lang es \
+  --file data.json
 ```

--- a/script/README.md
+++ b/script/README.md
@@ -1,0 +1,25 @@
+# `script` directory
+
+Command line utilities for translating text or JSON using the library.
+
+## Translate a short text
+
+```sh
+deno run jsr:@baiq/translator/script/translateText \
+  --engine openai \
+  --model gpt-4o \
+  --lang es \
+  --text "Hello"
+```
+
+This is also the default when running `jsr:@baiq/translator/script`.
+
+## Translate a JSON file
+
+```sh
+deno run jsr:@baiq/translator/script/translateJSON \
+  --engine google \
+  --model gemini-1.5-flash \
+  --lang fr \
+  --file data.json
+```

--- a/script/mod.ts
+++ b/script/mod.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net
+
+// Default CLI entry runs the text translator
+import "./translateText.ts";

--- a/script/translateJSON.ts
+++ b/script/translateJSON.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net --allow-read
+
+import { parse } from "https://deno.land/std@0.224.0/flags/mod.ts";
+import {
+  configureLangChain,
+  type GoogleModel,
+  type LangChainConfig,
+  type OpenAIModel,
+  translateJson,
+  translateText,
+} from "../mod.ts";
+
+const args = parse(Deno.args, {
+  string: ["engine", "model", "lang", "file", "key"],
+  alias: { e: "engine", m: "model", l: "lang", f: "file", k: "key" },
+});
+
+if (!args.engine || !args.model || !args.lang || !args.file) {
+  console.error(
+    "Usage: deno run jsr:@baiq/translator/script/translateJSON --engine <openai|google> --model <model> --lang <lang> --file <path> [--key <api-key>]",
+  );
+  Deno.exit(1);
+}
+
+const apiKey = args.key ??
+  Deno.env.get(
+    args.engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
+  ) ?? "";
+
+if (!apiKey) {
+  console.error("API key must be provided via --key or environment variable");
+  Deno.exit(1);
+}
+
+let config: LangChainConfig;
+if (args.engine === "openai") {
+  config = {
+    name: "openai",
+    model: args.model as OpenAIModel,
+    apiKey,
+  };
+} else {
+  config = {
+    name: "google",
+    model: args.model as GoogleModel,
+    apiKey,
+  };
+}
+
+const fileContent = await Deno.readTextFile(args.file);
+const jsonData = JSON.parse(fileContent);
+
+const chat = configureLangChain(config);
+const result = await translateJson(
+  jsonData,
+  args.lang,
+  (text, lang) => translateText(text, lang, chat),
+);
+
+console.log(JSON.stringify(result, null, 2));

--- a/script/translateText.ts
+++ b/script/translateText.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net
+
+import { parse } from "https://deno.land/std@0.224.0/flags/mod.ts";
+import {
+  configureLangChain,
+  type GoogleModel,
+  type LangChainConfig,
+  type OpenAIModel,
+  translateText,
+} from "../mod.ts";
+
+const args = parse(Deno.args, {
+  string: ["engine", "model", "lang", "text", "key"],
+  alias: { e: "engine", m: "model", l: "lang", t: "text", k: "key" },
+});
+
+if (!args.engine || !args.model || !args.lang || !args.text) {
+  console.error(
+    "Usage: deno run jsr:@baiq/translator/script/translateText --engine <openai|google> --model <model> --lang <lang> --text <text> [--key <api-key>]",
+  );
+  Deno.exit(1);
+}
+
+const apiKey = args.key ??
+  Deno.env.get(
+    args.engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
+  ) ?? "";
+
+if (!apiKey) {
+  console.error("API key must be provided via --key or environment variable");
+  Deno.exit(1);
+}
+
+let config: LangChainConfig;
+if (args.engine === "openai") {
+  config = {
+    name: "openai",
+    model: args.model as OpenAIModel,
+    apiKey,
+  };
+} else {
+  config = {
+    name: "google",
+    model: args.model as GoogleModel,
+    apiKey,
+  };
+}
+
+const chat = configureLangChain(config);
+const result = await translateText(args.text, args.lang, chat);
+console.log(result);

--- a/text/README.md
+++ b/text/README.md
@@ -9,10 +9,20 @@ import { configureLangChain, translateText } from "../mod.ts";
 
 const chat = configureLangChain({
   name: "openai",
-  model: "gpt-3.5-turbo",
+  model: "gpt-4o",
   apiKey: "YOUR_OPENAI_KEY",
 });
 
 const greeting = await translateText("Hello", "de", chat);
 console.log(greeting); // Hallo
+```
+
+### CLI
+
+```sh
+deno run jsr:@baiq/translator/script/translateText \
+  --engine openai \
+  --model gpt-4o \
+  --lang de \
+  --text "Hello"
 ```

--- a/text/translateText.ts
+++ b/text/translateText.ts
@@ -27,9 +27,11 @@ const translateText = async (
   targetLang: string,
   chat: ChatOpenAI | ChatGoogleGenerativeAI,
 ): Promise<string> => {
-  const prompt = `Translate the following text to ${targetLang}: ${text}. ` +
-    "Do not include any additional text or formatting. Just return the translated text. " +
-    "Text is aimed for a web application, so keep it concise and clear.";
+  const prompt = `Translate the following text to ${targetLang}. ` +
+    "The input may contain Markdown, HTML or embedded JSON. " +
+    "Keep the exact same structure and only translate the textual content. " +
+    "Do not add any extra text or formatting.\n\n" +
+    text;
   const response = await chat.invoke([
     new HumanMessage(prompt),
   ]);


### PR DESCRIPTION
## Summary
- expand LangChain configuration with all known OpenAI and Google models
- update translation prompt to preserve Markdown/HTML/JSON
- add CLI script under `script/` to translate text
- document examples and CLI usage
- update examples to use new models
- add dedicated CLI for translating JSON

## Testing
- `deno fmt`
- `deno lint` *(fails: invalid peer certificate)*
- `deno test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_b_685125b78cb483308892d3e801dbe768