### PR TITLE
Add CLI tests

### DIFF
--- a/script/cli_test.ts
+++ b/script/cli_test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+
+async function run(args: string[], env: Record<string, string>) {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-env", ...args],
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await cmd.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+Deno.test("translateText CLI", async () => {
+  const { code, stdout } = await run([
+    "script/translateText.ts",
+    "--engine",
+    "openai",
+    "--model",
+    "gpt-4o",
+    "--lang",
+    "fr",
+    "--text",
+    "Hello",
+    "--key",
+    "dummy",
+  ], { CLI_TEST_MODE: "1" });
+  assert.equal(code, 0);
+  assert.equal(stdout.trim(), "Hello-fr");
+});
+
+Deno.test("translateJSON CLI", async () => {
+  const tmp = await Deno.makeTempFile({ suffix: ".json" });
+  await Deno.writeTextFile(tmp, JSON.stringify({ greeting: "Hello" }));
+  const { code, stdout } = await run([
+    "--allow-read",
+    "script/translateJSON.ts",
+    "--engine",
+    "openai",
+    "--model",
+    "gpt-4o",
+    "--lang",
+    "fr",
+    "--file",
+    tmp,
+    "--key",
+    "dummy",
+  ], { CLI_TEST_MODE: "1" });
+  assert.equal(code, 0);
+  const out = JSON.parse(stdout);
+  assert.deepEqual(out, { greeting: "Hello-fr" });
+});

--- a/script/translateText.ts
+++ b/script/translateText.ts
@@ -9,6 +9,15 @@ import {
   translateText,
 } from "../mod.ts";
 
+let translateTextImpl = translateText;
+let configureLangChainImpl = configureLangChain;
+
+if (Deno.env.get("CLI_TEST_MODE")) {
+  translateTextImpl = (text: string, lang: string) =>
+    Promise.resolve(`${text}-${lang}`);
+  configureLangChainImpl = (_cfg: LangChainConfig) => ({} as unknown);
+}
+
 const args = parse(Deno.args, {
   string: ["engine", "model", "lang", "text", "key"],
   alias: { e: "engine", m: "model", l: "lang", t: "text", k: "key" },
@@ -46,6 +55,6 @@ if (args.engine === "openai") {
   };
 }
 
-const chat = configureLangChain(config);
-const result = await translateText(args.text, args.lang, chat);
+const chat = configureLangChainImpl(config);
+const result = await translateTextImpl(args.text, args.lang, chat);
 console.log(result);


### PR DESCRIPTION
## Summary
- add CLI unit tests
- allow tests to run with CLI_TEST_MODE

## Testing
- `deno fmt`
- `deno lint` *(fails: invalid peer certificate for npm packages)*
- `deno task test` *(fails: invalid peer certificate for npm packages)*

------
https://chatgpt.com/codex/tasks/task_b_685128d01f9c8330b0cc4d1184fddcfa