### PR TITLE
Add XML CLI and library parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # translator
 
-Utilities for translating plain text or the values of JSON objects using
-LangChain chat models.
+Utilities for translating plain text, JSON, or XML content using LangChain chat
+models.
 
 ## Usage
 
@@ -34,6 +34,19 @@ console.log(translated);
 // { greeting: "Bonjour", nested: { bye: "Au revoir" } }
 ```
 
+### XML translation
+
+```ts
+const xml = `<page><paragraph><line>Hello</line></paragraph></page>`;
+const translatedXml = await translateXML(
+  xml,
+  "fr",
+  (text, lang) => translateText(text, lang, chat),
+  "paragraph",
+);
+console.log(translatedXml);
+```
+
 ### CLI usage
 
 Translate a short text directly from the command line:
@@ -54,6 +67,17 @@ deno run jsr:@baiq/translator/cli/translateJSON \
   --model=gemini-1.5-flash \
   --lang=fr \
   --file=data.json
+```
+
+You can also translate an XML file:
+
+```sh
+deno run jsr:@baiq/translator/cli/translateXML \
+  --engine=openai \
+  --model=gpt-4o \
+  --lang=fr \
+  --file=page.xml \
+  --stopTag=paragraph
 ```
 
 Both commands also accept an `--key` flag for providing the API key explicitly.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # `cli` directory
 
-Command line utilities for translating text or JSON using the library.
+Command line utilities for translating text, JSON, or XML using the library.
 
 Each command reads the API key from either the command line (`--key`) or the
 appropriate environment variable (`OPENAI_API_KEY` or `GOOGLE_API_KEY`).
@@ -25,4 +25,15 @@ deno run jsr:@baiq/translator/cli/translateJSON \
   --model gemini-1.5-flash \
   --lang fr \
   --file data.json
+```
+
+## Translate an XML file
+
+```sh
+deno run jsr:@baiq/translator/cli/translateXML \
+  --engine openai \
+  --model gpt-4o \
+  --lang fr \
+  --file data.xml \
+  --stopTag paragraph
 ```

--- a/cli/cli_test.ts
+++ b/cli/cli_test.ts
@@ -72,3 +72,25 @@ Deno.test("translateJSON CLI", async () => {
   });
   await Deno.remove(tmp);
 });
+
+Deno.test("translateXML CLI", async () => {
+  const tmp = await Deno.makeTempFile({ suffix: ".xml" });
+  await Deno.writeTextFile(
+    tmp,
+    "<root><a>Hello</a><b>World</b></root>",
+  );
+  const { code, stdout } = await run(
+    [
+      "translateXML.ts",
+      "--engine=openai",
+      "--model=gpt-4o",
+      "--lang=fr",
+      "--file=" + tmp,
+      "--key=dummy",
+    ],
+    { CLI_TEST_MODE: "1" },
+  );
+  assert.equal(code, 0);
+  assert.equal(stdout.trim(), "<root><a>Hello-fr</a><b>World-fr</b></root>");
+  await Deno.remove(tmp);
+});

--- a/cli/translateXML.ts
+++ b/cli/translateXML.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net --allow-read
+
+// CLI helper that translates XML files recursively. The API key can be provided
+// via --key or read from OPENAI_API_KEY/GOOGLE_API_KEY.
+
+import { parseArgs } from "@std/cli/parse-args";
+
+import {
+  configureLangChain,
+  type LangChainConfig,
+  translateText,
+  translateXML,
+} from "../mod.ts";
+import type { GoogleModel, OpenAIModel } from "../LangChainConfig.ts";
+import type { ChatOpenAI, ChatOpenAICallOptions } from "@langchain/openai";
+import type { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+
+let translateTextImpl = translateText;
+let configureLangChainImpl = configureLangChain;
+
+if (Deno.env.get("CLI_TEST_MODE")) {
+  translateTextImpl = (text: string, lang: string) =>
+    Promise.resolve(`${text}-${lang}`);
+  configureLangChainImpl = (
+    _cfg: LangChainConfig,
+  ) => ({} as ChatOpenAI<ChatOpenAICallOptions> | ChatGoogleGenerativeAI);
+}
+
+const args = parseArgs(Deno.args, {
+  string: ["engine", "model", "lang", "file", "stopTag", "key"],
+});
+
+if (!args.engine || !args.model || !args.lang || !args.file) {
+  console.error(
+    "Usage: deno run jsr:@baiq/translator/cli/translateXML --engine=<openai|google> --model=<model> --lang=<lang> --file=<path-to-xml-file> [--stopTag=<tag>] [--key=<api-key>]",
+  );
+  Deno.exit(1);
+}
+
+const apiKey = args.key ??
+  Deno.env.get(
+    args.engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
+  ) ??
+  "";
+
+if (!apiKey) {
+  console.error("API key must be provided via --key or environment variable");
+  Deno.exit(1);
+}
+
+let config: LangChainConfig;
+if (args.engine === "openai") {
+  config = {
+    name: "openai",
+    model: args.model as OpenAIModel,
+    apiKey,
+  };
+} else {
+  config = {
+    name: "google",
+    model: args.model as GoogleModel,
+    apiKey,
+  };
+}
+
+const xml = await Deno.readTextFile(args.file);
+const chat = configureLangChainImpl(config);
+const result = await translateXML(
+  xml,
+  args.lang,
+  (text, lang) => translateTextImpl(text, lang, chat),
+  args.stopTag,
+);
+
+console.log(result);

--- a/deno.json
+++ b/deno.json
@@ -5,8 +5,10 @@
     ".": "./mod.ts",
     "./json": "./json/mod.ts",
     "./text": "./text/mod.ts",
+    "./xml": "./xml/mod.ts",
     "./cli/translateText": "./cli/translateText.ts",
-    "./cli/translateJSON": "./cli/translateJSON.ts"
+    "./cli/translateJSON": "./cli/translateJSON.ts",
+    "./cli/translateXML": "./cli/translateXML.ts"
   },
   "license": "MIT",
   "imports": {
@@ -14,13 +16,15 @@
     "@langchain/google-genai": "npm:@langchain/google-genai@^0.2.12",
     "@langchain/openai": "npm:@langchain/openai@^0.5.13",
     "@std/cli": "jsr:@std/cli@^1.0.20",
-    "@std/flags": "jsr:@std/flags@^0.224.0"
+    "@std/flags": "jsr:@std/flags@^0.224.0",
+    "linkedom": "npm:linkedom@^0.15.1"
   },
   "tasks": {
     "test:cli": "cd cli && CLI_TEST_MODE=true deno test --allow-read --allow-write --allow-run --allow-env --allow-net cli_test.ts",
     "test:json": "cd json && deno test --allow-read --allow-write --allow-env --allow-net translateJSON_test.ts",
     "test:text": "cd text && deno test --allow-read --allow-write --allow-env --allow-net translateText_test.ts",
-    "test": "deno task test:cli && deno task test:json && deno task test:text",
+    "test:xml": "cd xml && deno test --allow-read --allow-write --allow-env --allow-net translateXML_test.ts",
+    "test": "deno task test:cli && deno task test:json && deno task test:text && deno task test:xml",
     "lint": "deno lint --unstable",
     "fmt": "deno fmt",
     "check": "deno fmt && deno check"

--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,7 @@
  */
 import translateJSON from "./json/mod.ts";
 import translateText from "./text/mod.ts";
+import translateXML from "./xml/mod.ts";
 import {
   configureLangChain,
   type GoogleModel,
@@ -14,5 +15,5 @@ import {
   type OpenAIModel,
 } from "./LangChainConfig.ts";
 
-export { configureLangChain, translateJSON, translateText };
+export { configureLangChain, translateJSON, translateText, translateXML };
 export type { GoogleModel, LangChainConfig, OpenAIModel };

--- a/text/translateText.ts
+++ b/text/translateText.ts
@@ -25,7 +25,7 @@ import { HumanMessage } from "@langchain/core/messages";
 const translateText = async (
   text: string,
   targetLang: string,
-  chat: ChatOpenAI | ChatGoogleGenerativeAI
+  chat: ChatOpenAI | ChatGoogleGenerativeAI,
 ): Promise<string> => {
   const prompt = [
     `You are a professional translator.`,

--- a/xml/README.md
+++ b/xml/README.md
@@ -1,0 +1,28 @@
+# `xml` module
+
+Helpers for translating XML strings using the
+[`linkedom`](https://www.npmjs.com/package/linkedom) DOM implementation.
+
+Nested tags are handled recursively. When the specified `stopTag` is
+encountered, its contents are sent as a single block for translation.
+
+## Example
+
+```ts
+import { configureLangChain, translateText, translateXML } from "../mod.ts";
+
+const chat = configureLangChain({
+  name: "google",
+  model: "gemini-1.5-flash",
+  apiKey: "YOUR_GOOGLE_KEY",
+});
+
+const xml = `<page><paragraph>Hello <line>World</line></paragraph></page>`;
+const translated = await translateXML(
+  xml,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+  "paragraph",
+);
+console.log(translated);
+```

--- a/xml/mod.ts
+++ b/xml/mod.ts
@@ -1,0 +1,7 @@
+/**
+ * Convenience wrapper re-exporting {@link translateXML} for users who want to import from `jsr:@baiq/translator/xml`.
+ */
+import translateXML from "./translateXML.ts";
+
+/** Re-export of {@link translateXML}. */
+export default translateXML;

--- a/xml/translateXML.ts
+++ b/xml/translateXML.ts
@@ -1,0 +1,50 @@
+import { DOMParser, XMLSerializer } from "npm:linkedom";
+
+/**
+ * Recursively translate the text content of an XML string.
+ *
+ * @param xml The XML content to translate.
+ * @param targetLang ISO language code to translate to.
+ * @param translateTextFn Function used to translate text segments.
+ * @param stopTag When encountered, the content inside this tag will be sent as a
+ *   whole to the translator without further recursion.
+ * @returns The translated XML as string.
+ */
+const translateXML = async (
+  xml: string,
+  targetLang: string,
+  translateTextFn: (text: string, targetLang: string) => Promise<string>,
+  stopTag?: string,
+): Promise<string> => {
+  const parser = new DOMParser();
+  const serializer = new XMLSerializer();
+  const { document } = parser.parseFromString(xml, "application/xml");
+
+  async function translateNode(node: Node): Promise<void> {
+    for (const child of Array.from(node.childNodes)) {
+      if (child.nodeType === 3) {
+        child.nodeValue = await translateTextFn(
+          child.nodeValue ?? "",
+          targetLang,
+        );
+      } else if (child.nodeType === 1) {
+        const element = child as Element;
+        if (stopTag && element.tagName === stopTag) {
+          const inner = Array.from(element.childNodes).map((n) =>
+            serializer.serializeToString(n)
+          ).join("");
+          const translated = await translateTextFn(inner, targetLang);
+          while (element.firstChild) element.removeChild(element.firstChild);
+          element.appendChild(document.createTextNode(translated));
+        } else {
+          await translateNode(element);
+        }
+      }
+    }
+  }
+
+  await translateNode(document);
+  return serializer.serializeToString(document);
+};
+
+export default translateXML;

--- a/xml/translateXML_test.ts
+++ b/xml/translateXML_test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import translateXML from "./translateXML.ts";
+
+const stubTranslate = (text: string, lang: string) =>
+  Promise.resolve(`${text}-${lang}`);
+
+Deno.test("translates simple xml", async () => {
+  const input = "<root><a>Hello</a><b>World</b></root>";
+  const result = await translateXML(input, "fr", stubTranslate);
+  assert.equal(result, "<root><a>Hello-fr</a><b>World-fr</b></root>");
+});
+
+Deno.test("stops recursion at tag", async () => {
+  const input =
+    "<page><paragraph><line>A example of paragraph</line><line>Another line</line></paragraph></page>";
+  const result = await translateXML(input, "es", stubTranslate, "paragraph");
+  assert.equal(
+    result,
+    `<page><paragraph><line>A example of paragraph</line><line>Another line</line>-es</paragraph></page>`,
+  );
+});


### PR DESCRIPTION
## Summary
- use `linkedom` library in XML translation
- provide new `translateXML` CLI command
- document XML CLI usage
- expose CLI in `deno.json`

## Testing
- `deno fmt`
- `deno lint` *(fails: Failed loading https://registry.npmjs.org/linkedom for package "linkedom". Invalid peer certificate)*
- `deno task test:xml` *(fails: Failed loading https://registry.npmjs.org/linkedom for package "linkedom")*

------
https://chatgpt.com/codex/tasks/task_b_68515acf0d6c8330866c680553767530