### PR TITLE
Use deno-dom for xml parsing

### DIFF
--- a/cli/cli_test.ts
+++ b/cli/cli_test.ts
@@ -40,7 +40,7 @@ Deno.test("translateText CLI", async () => {
       "--text=Hello",
       "--key=dummy",
     ],
-    { CLI_TEST_MODE: "1" }
+    { CLI_TEST_MODE: "1" },
   );
   assertEquals(code, 0);
   assertEquals(stdout.trim(), "Hello-fr");
@@ -50,7 +50,7 @@ Deno.test("translateJSON CLI", async () => {
   const tmp = await Deno.makeTempFile({ suffix: ".json" });
   await Deno.writeTextFile(
     tmp,
-    JSON.stringify({ greeting: "Hello", nested: { value: "World" } })
+    JSON.stringify({ greeting: "Hello", nested: { value: "World" } }),
   );
   const { code, stdout } = await run(
     [
@@ -61,7 +61,7 @@ Deno.test("translateJSON CLI", async () => {
       "--file=" + tmp,
       "--key=dummy",
     ],
-    { CLI_TEST_MODE: "1" }
+    { CLI_TEST_MODE: "1" },
   );
 
   assertEquals(code, 0);
@@ -85,12 +85,12 @@ Deno.test("translateXML CLI", async () => {
       "--file=" + tmp,
       "--key=dummy",
     ],
-    { CLI_TEST_MODE: "1" }
+    { CLI_TEST_MODE: "1" },
   );
   assertEquals(code, 0);
   assertEquals(
     stdout.trim(),
-    '<?xml version="1.0" encoding="utf-8"?><root><a>Hello-fr</a><b>World-fr</b></root>'
+    '<?xml version="1.0" encoding="utf-8"?><root><a>Hello-fr</a><b>World-fr</b></root>',
   );
   await Deno.remove(tmp);
 });

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,7 @@
     "@std/assert": "jsr:@std/assert@^1.0.13",
     "@std/cli": "jsr:@std/cli@^1.0.20",
     "@std/flags": "jsr:@std/flags@^0.224.0",
-    "linkedom": "npm:linkedom@^0.18.11"
+    "deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49"
   },
   "tasks": {
     "test:cli": "cd cli && CLI_TEST_MODE=true deno test --allow-read --allow-write --allow-run --allow-env --allow-net cli_test.ts",

--- a/xml/README.md
+++ b/xml/README.md
@@ -1,7 +1,7 @@
 # `xml` module
 
 Helpers for translating XML strings using the
-[`linkedom`](https://www.npmjs.com/package/linkedom) DOM implementation.
+[`deno-dom`](https://jsr.io/@b-fuze/deno-dom) DOM implementation.
 
 Nested tags are handled recursively. When the specified `stopTag` is
 encountered, its contents are sent as a single block for translation.

--- a/xml/translateXML.ts
+++ b/xml/translateXML.ts
@@ -1,5 +1,4 @@
-/// <reference lib="dom" />
-import { DOMParser } from "linkedom";
+import { DOMParser } from "deno-dom";
 
 /**
  * Recursively translate the text content of an XML string.


### PR DESCRIPTION
## Summary
- migrate XML helpers from `linkedom` to the verified `deno-dom` package
- update import map accordingly
- refresh README references
- format test file

## Testing
- `deno fmt`
- `deno lint` *(fails: JSR package manifest for '@b-fuze/deno-dom' failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_6851656379c88330ac5a5d132bcd6c95