### PR TITLE
Add XML file translation example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,3 +30,9 @@ deno run jsr:@baiq/translator/cli/translateJSON \
   --lang fr \
   --file data.json
 ```
+
+You can also translate XML files:
+
+```sh
+deno run -A examples/translate_xml.ts
+```

--- a/examples/translate_xml.ts
+++ b/examples/translate_xml.ts
@@ -1,0 +1,20 @@
+import { configureLangChain, translateText, translateXML } from "../mod.ts";
+
+// Example: translate an XML file using OpenAI. Requires OPENAI_API_KEY to be
+// set in the environment.
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-4o",
+  apiKey: Deno.env.get("OPENAI_API_KEY") ?? "", // replace with your key
+});
+
+// Path to the XML file you want to translate.
+const xml = await Deno.readTextFile("data.xml");
+
+const translated = await translateXML(
+  xml,
+  "fr",
+  (text, lang) => translateText(text, lang, chat),
+);
+console.log(translated);


### PR DESCRIPTION
## Summary
- add `translate_xml.ts` example script
- document running the new example in `examples/README.md`

## Testing
- `deno fmt examples/translate_xml.ts examples/README.md`
- `deno lint examples/translate_xml.ts examples/README.md` *(fails: JSR package manifest for '@std/cli' failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_685183ff19188330ae7f5ca35cdfd446