### PR TITLE
Add attribute support for XML translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ const translatedXml = await translateXML(
 console.log(translatedXml);
 ```
 
+### Translate HTML attributes
+
+```ts
+const html = "<img alt='A cat' src='cat.jpg'><p>Hello</p>";
+const translatedHtml = await translateXML(
+  html,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+  undefined,
+  ["alt"],
+);
+console.log(translatedHtml);
+```
+
 ### CLI usage
 
 Translate a short text directly from the command line:

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,3 +36,9 @@ You can also translate XML files:
 ```sh
 deno run -A examples/translate_xml.ts
 ```
+
+Translate an HTML snippet with attribute translation:
+
+```sh
+deno run -A examples/translate_html.ts
+```

--- a/examples/translate_html.ts
+++ b/examples/translate_html.ts
@@ -1,0 +1,21 @@
+import { configureLangChain, translateText, translateXML } from "../mod.ts";
+
+// Example: translate an HTML snippet and also translate the alt attribute.
+// Requires OPENAI_API_KEY to be set in the environment.
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-4o",
+  apiKey: Deno.env.get("OPENAI_API_KEY") ?? "", // replace with your key
+});
+
+const html = "<img alt='A cute cat' src='cat.jpg'><p>Hello world</p>";
+
+const translated = await translateXML(
+  html,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+  undefined,
+  ["alt"],
+);
+console.log(translated);

--- a/xml/README.md
+++ b/xml/README.md
@@ -3,7 +3,8 @@
 Helpers for translating XML strings without any third-party DOM library.
 
 Nested tags are handled recursively. When the specified `stopTag` is
-encountered, its contents are sent as a single block for translation.
+encountered, its contents are sent as a single block for translation. You can
+also specify attribute names that should be translated.
 
 ## Example
 
@@ -16,12 +17,13 @@ const chat = configureLangChain({
   apiKey: "YOUR_GOOGLE_KEY",
 });
 
-const xml = `<page><paragraph>Hello <line>World</line></paragraph></page>`;
+const xml = `<figure><img alt="A cat" src="cat.jpg" /></figure>`;
 const translated = await translateXML(
   xml,
   "es",
   (text, lang) => translateText(text, lang, chat),
-  "paragraph",
+  undefined,
+  ["alt"],
 );
 console.log(translated);
 ```

--- a/xml/translateXML_test.ts
+++ b/xml/translateXML_test.ts
@@ -16,6 +16,21 @@ Deno.test("stops recursion at tag", async () => {
   const result = await translateXML(input, "es", stubTranslate, "paragraph");
   assertEquals(
     result,
-    `<page><paragraph><line>A example of paragraph</line><line>Another line</line>-es</paragraph></page>`
+    `<page><paragraph><line>A example of paragraph</line><line>Another line</line>-es</paragraph></page>`,
+  );
+});
+
+Deno.test("translates selected attributes", async () => {
+  const input = "<img alt='Hello world' title='No change'/><p>Hi</p>";
+  const result = await translateXML(
+    input,
+    "fr",
+    stubTranslate,
+    undefined,
+    ["alt"],
+  );
+  assertEquals(
+    result,
+    '<img alt="Hello world-fr" title="No change"/><p>Hi-fr</p>',
   );
 });


### PR DESCRIPTION
## Summary
- support translating chosen XML attributes
- test translating an attribute
- document translating HTML attributes
- add example of translating HTML with `alt` attribute

## Testing
- `deno lint` *(fails: JSR package manifest for '@std/cli' failed to load)*
- `deno task test` *(fails: Failed caching npm package 'dunder-proto@1.0.1')*

------
https://chatgpt.com/codex/tasks/task_b_6852994686008330b068aee4aa2431a8