### PR TITLE
Add attribute translation to translateXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ const translatedXml = await translateXML(
 console.log(translatedXml);
 ```
 
+To translate attributes such as `alt` in HTML, pass the attribute names as the
+last argument:
+
+```ts
+const html = '<img alt="Hello" src="pic.png" />';
+const translatedHtml = await translateXML(
+  html,
+  "fr",
+  (text, lang) => translateText(text, lang, chat),
+  undefined,
+  ["alt"],
+);
+console.log(translatedHtml);
+```
+
 ### CLI usage
 
 Translate a short text directly from the command line:

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,3 +36,10 @@ You can also translate XML files:
 ```sh
 deno run -A examples/translate_xml.ts
 ```
+
+To translate specific HTML attributes, try the following example which
+translates the `alt` attribute:
+
+```sh
+deno run -A examples/translate_html_alt.ts
+```

--- a/examples/translate_html_alt.ts
+++ b/examples/translate_html_alt.ts
@@ -1,0 +1,21 @@
+import { configureLangChain, translateText, translateXML } from "../mod.ts";
+
+// Translate an HTML snippet and also translate the alt attribute.
+// Requires OPENAI_API_KEY to be set in the environment.
+
+const chat = configureLangChain({
+  name: "openai",
+  model: "gpt-4o",
+  apiKey: Deno.env.get("OPENAI_API_KEY") ?? "", // replace with your key
+});
+
+const html = '<img alt="A cat" src="cat.png" />';
+
+const translated = await translateXML(
+  html,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+  undefined,
+  ["alt"],
+);
+console.log(translated);

--- a/xml/README.md
+++ b/xml/README.md
@@ -4,7 +4,8 @@ Helpers for translating XML strings without any third-party DOM library.
 
 Nested tags are handled recursively. When any of the specified `stopTags` is
 encountered, its contents are sent as a single block for translation. Multiple
-tag names can be provided.
+tag names can be provided. Attributes are normally left as-is but you can
+specify a list of attribute names that should be translated.
 
 ## Example
 
@@ -25,4 +26,19 @@ const translated = await translateXML(
   ["paragraph", "note"],
 );
 console.log(translated);
+```
+
+If you want to translate specific attributes, pass their names in the last
+argument:
+
+```ts
+const html = '<img alt="Hello" src="pic.png" />';
+const result = await translateXML(
+  html,
+  "es",
+  (text, lang) => translateText(text, lang, chat),
+  undefined,
+  ["alt"],
+);
+console.log(result); // <img alt="Hola" src="pic.png" />
 ```

--- a/xml/translateXML_test.ts
+++ b/xml/translateXML_test.ts
@@ -34,3 +34,15 @@ Deno.test("handles multiple stop tags", async () => {
     `<page><paragraph>Hello <i>World</i>-de</paragraph><note>Other <b>Text</b>-de</note></page>`,
   );
 });
+
+Deno.test("translates selected attributes", async () => {
+  const input = '<img alt="Hello" src="x.png" />';
+  const result = await translateXML(
+    input,
+    "fr",
+    stubTranslate,
+    undefined,
+    ["alt"],
+  );
+  assertEquals(result, '<img alt="Hello-fr" src="x.png" />');
+});


### PR DESCRIPTION
## Summary
- allow specifying attributes to translate in `translateXML`
- support attribute translation in recursive helper
- add tests for attribute translation
- document attribute translation with examples
- add HTML attribute example script

## Testing
- `deno fmt xml/translateXML.ts xml/translateXML_test.ts examples/translate_html_alt.ts examples/README.md README.md xml/README.md`
- `deno lint xml/translateXML.ts xml/translateXML_test.ts examples/translate_html_alt.ts` *(fails: JSR package manifest for '@std/cli' failed to load)*
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_68529abc0f788330b65a4cb2852cd6b7