### PR TITLE
Add Node support for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ deno run jsr:@baiq/translator/cli/translateText \
   --text="Hello"
 ```
 
+When running in Node, execute the compiled script (or use `ts-node`) with the
+same flags:
+
+```sh
+node cli/translateText.js --engine=openai --model=gpt-4o --lang=fr --text "Hello"
+```
+
 You can also translate a JSON file:
 
 ```sh
@@ -96,3 +103,4 @@ deno run jsr:@baiq/translator/cli/translateXML \
 ```
 
 Both commands also accept an `--key` flag for providing the API key explicitly.
+The scripts behave the same when run under Node.

--- a/cli/README.md
+++ b/cli/README.md
@@ -3,7 +3,8 @@
 Command line utilities for translating text, JSON, or XML using the library.
 
 Each command reads the API key from either the command line (`--key`) or the
-appropriate environment variable (`OPENAI_API_KEY` or `GOOGLE_API_KEY`).
+appropriate environment variable (`OPENAI_API_KEY` or `GOOGLE_API_KEY`). The
+scripts can also be executed with Node after compilation or via `ts-node`.
 
 ## Translate a short text
 
@@ -13,6 +14,12 @@ deno run jsr:@baiq/translator/cli/translateText \
   --model=gpt-4o \
   --lang=es \
   --text="Hello"
+```
+
+With Node you can run the compiled file in the same way:
+
+```sh
+node translateText.js --engine=openai --model=gpt-4o --lang=es --text "Hello"
 ```
 
 This is also the default when running `jsr:@baiq/translator/cli`.
@@ -27,6 +34,10 @@ deno run jsr:@baiq/translator/cli/translateJSON \
   --file=data.json
 ```
 
+```sh
+node translateJSON.js --engine=google --model=gemini-1.5-flash --lang=fr --file=data.json
+```
+
 ## Translate an XML file
 
 The `--stopTags` flag accepts a comma-separated list of tag names whose contents
@@ -39,4 +50,8 @@ deno run jsr:@baiq/translator/cli/translateXML \
   --lang=fr \
   --file=data.xml \
   --stopTags=paragraph,note
+```
+
+```sh
+node translateXML.js --engine=openai --model=gpt-4o --lang=fr --file=data.xml --stopTags=paragraph,note
 ```

--- a/cli/runtime.ts
+++ b/cli/runtime.ts
@@ -1,0 +1,48 @@
+import process from "node:process";
+
+export const isDeno = typeof Deno !== "undefined" && !!Deno?.version?.deno;
+
+export function getArgs(): string[] {
+  return isDeno ? Deno.args : process.argv.slice(2);
+}
+
+export function getEnv(key: string): string | undefined {
+  return isDeno ? Deno.env.get(key) ?? undefined : process.env[key];
+}
+
+export async function readText(path: string): Promise<string> {
+  if (isDeno) return await Deno.readTextFile(path);
+  const fs = await import("node:fs/promises");
+  return await fs.readFile(path, "utf8");
+}
+
+export function exit(code: number): never {
+  if (isDeno) {
+    Deno.exit(code);
+  } else {
+    process.exit(code);
+  }
+  throw new Error("unreachable");
+}
+
+export function parseCliArgs(args: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+    const withoutPrefix = arg.slice(2);
+    if (withoutPrefix.includes("=")) {
+      const [key, val] = withoutPrefix.split("=");
+      result[key] = val;
+    } else {
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) {
+        result[withoutPrefix] = next;
+        i++;
+      } else {
+        result[withoutPrefix] = true;
+      }
+    }
+  }
+  return result;
+}

--- a/cli/translateJSON.ts
+++ b/cli/translateJSON.ts
@@ -3,7 +3,7 @@
 // CLI helper that translates JSON files recursively. The API key can be passed
 // via `--key` or taken from `OPENAI_API_KEY`/`GOOGLE_API_KEY`.
 
-import { parseArgs } from "@std/cli/parse-args";
+import { exit, getArgs, getEnv, parseCliArgs, readText } from "./runtime.ts";
 
 import {
   configureLangChain,
@@ -18,58 +18,63 @@ import type { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 let translateTextImpl = translateText;
 let configureLangChainImpl = configureLangChain;
 
-const args = parseArgs(Deno.args, {
-  string: ["engine", "model", "lang", "file", "key"],
-  boolean: ["testMode"],
-});
+const rawArgs = parseCliArgs(getArgs()) as Record<string, string | boolean>;
 
-if (args.testMode) {
+const engine = typeof rawArgs.engine === "string" ? rawArgs.engine : "";
+const model = typeof rawArgs.model === "string" ? rawArgs.model : "";
+const lang = typeof rawArgs.lang === "string" ? rawArgs.lang : "";
+const file = typeof rawArgs.file === "string" ? rawArgs.file : "";
+const keyArg = typeof rawArgs.key === "string" ? rawArgs.key : undefined;
+
+if (rawArgs.testMode) {
   translateTextImpl = (text: string, lang: string) =>
     Promise.resolve(`${text}-${lang}`);
-  configureLangChainImpl = (_cfg: LangChainConfig) =>
-    ({} as ChatOpenAI<ChatOpenAICallOptions> | ChatGoogleGenerativeAI);
+  configureLangChainImpl = (
+    _cfg: LangChainConfig,
+  ) => ({} as ChatOpenAI<ChatOpenAICallOptions> | ChatGoogleGenerativeAI);
 }
 
-if (!args.engine || !args.model || !args.lang || !args.file) {
+if (!engine || !model || !lang || !file) {
   console.error(
-    "Usage: deno run jsr:@baiq/translator/cli/translateJSON --engine=<openai|google> --model=<model> --lang=<lang> --file=<path-to-json-file> [--key=<api-key>]"
+    "Usage: deno run jsr:@baiq/translator/cli/translateJSON --engine=<openai|google> --model=<model> --lang=<lang> --file=<path-to-json-file> [--key=<api-key>]",
   );
-  Deno.exit(1);
+  exit(1);
 }
 
-const apiKey =
-  args.key ??
-  Deno.env.get(
-    args.engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY"
+const apiKey = keyArg ??
+  getEnv(
+    engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
   ) ??
   "";
 
 if (!apiKey) {
   console.error("API key must be provided via --key or environment variable");
-  Deno.exit(1);
+  exit(1);
 }
 
 let config: LangChainConfig;
-if (args.engine === "openai") {
+if (engine === "openai") {
   config = {
     name: "openai",
-    model: args.model as OpenAIModel,
+    model: model as OpenAIModel,
     apiKey,
   };
 } else {
   config = {
     name: "google",
-    model: args.model as GoogleModel,
+    model: model as GoogleModel,
     apiKey,
   };
 }
 
-const fileContent = await Deno.readTextFile(args.file);
+const fileContent = await readText(file);
 const jsonData = JSON.parse(fileContent);
 
 const chat = configureLangChainImpl(config);
-const result = await translateJSON(jsonData, args.lang, (text, lang) =>
-  translateTextImpl(text, lang, chat)
+const result = await translateJSON(
+  jsonData,
+  lang,
+  (text, lang) => translateTextImpl(text, lang, chat),
 );
 
 console.log(JSON.stringify(result, null, 2));

--- a/cli/translateXML.ts
+++ b/cli/translateXML.ts
@@ -3,7 +3,7 @@
 // CLI helper that translates XML files recursively. The API key can be provided
 // via --key or read from OPENAI_API_KEY/GOOGLE_API_KEY.
 
-import { parseArgs } from "@std/cli/parse-args";
+import { exit, getArgs, getEnv, parseCliArgs, readText } from "./runtime.ts";
 
 import {
   configureLangChain,
@@ -18,12 +18,15 @@ import type { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 let translateTextImpl = translateText;
 let configureLangChainImpl = configureLangChain;
 
-const args = parseArgs(Deno.args, {
-  string: ["engine", "model", "lang", "file", "stopTag", "stopTags", "key"],
-  boolean: ["testMode"],
-});
+const rawArgs = parseCliArgs(getArgs()) as Record<string, string | boolean>;
 
-if (args.testMode) {
+const engine = typeof rawArgs.engine === "string" ? rawArgs.engine : "";
+const model = typeof rawArgs.model === "string" ? rawArgs.model : "";
+const lang = typeof rawArgs.lang === "string" ? rawArgs.lang : "";
+const file = typeof rawArgs.file === "string" ? rawArgs.file : "";
+const keyArg = typeof rawArgs.key === "string" ? rawArgs.key : undefined;
+
+if (rawArgs.testMode) {
   translateTextImpl = (text: string, lang: string) =>
     Promise.resolve(`${text}-${lang}`);
   configureLangChainImpl = (
@@ -31,52 +34,52 @@ if (args.testMode) {
   ) => ({} as ChatOpenAI<ChatOpenAICallOptions> | ChatGoogleGenerativeAI);
 }
 
-if (!args.engine || !args.model || !args.lang || !args.file) {
+if (!engine || !model || !lang || !file) {
   console.error(
     "Usage: deno run jsr:@baiq/translator/cli/translateXML --engine=<openai|google> --model=<model> --lang=<lang> --file=<path-to-xml-file> [--stopTags=<tag1,tag2>] [--key=<api-key>]",
   );
-  Deno.exit(1);
+  exit(1);
 }
 
-const apiKey = args.key ??
-  Deno.env.get(
-    args.engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
+const apiKey = keyArg ??
+  getEnv(
+    engine === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY",
   ) ??
   "";
 
 if (!apiKey) {
   console.error("API key must be provided via --key or environment variable");
-  Deno.exit(1);
+  exit(1);
 }
 
 let config: LangChainConfig;
-if (args.engine === "openai") {
+if (engine === "openai") {
   config = {
     name: "openai",
-    model: args.model as OpenAIModel,
+    model: model as OpenAIModel,
     apiKey,
   };
 } else {
   config = {
     name: "google",
-    model: args.model as GoogleModel,
+    model: model as GoogleModel,
     apiKey,
   };
 }
 
-const xml = await Deno.readTextFile(args.file);
+const xml = await readText(file);
 const chat = configureLangChainImpl(config);
-const stopTags = args.stopTags
-  ? String(args.stopTags)
+const stopTags = rawArgs.stopTags
+  ? String(rawArgs.stopTags)
     .split(",")
     .map((t) => t.trim())
     .filter(Boolean)
-  : args.stopTag
-  ? [String(args.stopTag)]
+  : rawArgs.stopTag
+  ? [String(rawArgs.stopTag)]
   : undefined;
 const result = await translateXML(
   xml,
-  args.lang,
+  lang,
   (text, lang) => translateTextImpl(text, lang, chat),
   stopTags,
 );

--- a/text/translateText.ts
+++ b/text/translateText.ts
@@ -24,7 +24,7 @@ import { HumanMessage } from "@langchain/core/messages";
 const translateText = async (
   text: string,
   targetLang: string,
-  chat: ChatOpenAI | ChatGoogleGenerativeAI
+  chat: ChatOpenAI | ChatGoogleGenerativeAI,
 ): Promise<string> => {
   const prompt = [
     `You are a professional translator.`,

--- a/xml/translateXML.ts
+++ b/xml/translateXML.ts
@@ -11,7 +11,7 @@ async function translateDomNode(
   targetLang: string,
   translateTextFn: (text: string, targetLang: string) => Promise<string>,
   stopTags?: string[],
-  attributesToTranslate?: string[]
+  attributesToTranslate?: string[],
 ): Promise<void> {
   if (node.nodeType === node.TEXT_NODE) {
     // Translate text nodes
@@ -28,7 +28,7 @@ async function translateDomNode(
           const originalValue = el.getAttribute(attrName) ?? "";
           const translatedValue = await translateTextFn(
             originalValue,
-            targetLang
+            targetLang,
           );
           el.setAttribute(attrName, translatedValue);
         }
@@ -51,7 +51,7 @@ async function translateDomNode(
         targetLang,
         translateTextFn,
         stopTags,
-        attributesToTranslate
+        attributesToTranslate,
       );
     }
   }
@@ -72,7 +72,7 @@ const translateXML = async (
   targetLang: string,
   translateTextFn: (text: string, targetLang: string) => Promise<string>,
   stopTags?: string[],
-  attributesToTranslate?: string[]
+  attributesToTranslate?: string[],
 ): Promise<string> => {
   // Parse as XML
   const dom = new JSDOM(xml, { contentType: "text/xml" });
@@ -84,7 +84,7 @@ const translateXML = async (
     targetLang,
     translateTextFn,
     stopTags,
-    attributesToTranslate
+    attributesToTranslate,
   );
 
   // Serialize back to XML

--- a/xml/translateXML_test.ts
+++ b/xml/translateXML_test.ts
@@ -16,7 +16,7 @@ Deno.test("stops recursion at tag", async () => {
   const result = await translateXML(input, "es", stubTranslate, ["paragraph"]);
   assertEquals(
     result,
-    `<page><paragraph><line>A example of paragraph</line><line>Another line</line>-es</paragraph></page>`
+    `<page><paragraph><line>A example of paragraph</line><line>Another line</line>-es</paragraph></page>`,
   );
 });
 
@@ -29,7 +29,7 @@ Deno.test("handles multiple stop tags", async () => {
   ]);
   assertEquals(
     result,
-    `<page><paragraph>Hello <i>World</i>-de</paragraph><note>Other <b>Text</b>-de</note></page>`
+    `<page><paragraph>Hello <i>World</i>-de</paragraph><note>Other <b>Text</b>-de</note></page>`,
   );
 });
 


### PR DESCRIPTION
## Summary
- add runtime utilities for Node/Deno checks
- update all CLI commands to use runtime helpers
- document Node usage in README files
- fix CLI argument typing to remove boolean unions

## Testing
- `deno fmt`
- `deno lint` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_b_6852e15fe9ec83309a9f222d25b1f857